### PR TITLE
Update teku.rb

### DIFF
--- a/teku.rb
+++ b/teku.rb
@@ -5,7 +5,7 @@ class Teku < Formula
   # update with: ./updateTeku.sh <new-version>
   sha256 "07c547f79cf8502ebed0469440ea2c577e420dbb0a374a7ff2680fff38e34be4"
 
-  depends_on :openjdk => "11+"
+  depends_on "openjdk" => "11+"
 
   def install
     cp_r ".", "#{prefix}/dist"

--- a/teku.rb
+++ b/teku.rb
@@ -5,7 +5,7 @@ class Teku < Formula
   # update with: ./updateTeku.sh <new-version>
   sha256 "07c547f79cf8502ebed0469440ea2c577e420dbb0a374a7ff2680fff38e34be4"
 
-  depends_on :java => "11+"
+  depends_on :openjdk => "11+"
 
   def install
     cp_r ".", "#{prefix}/dist"


### PR DESCRIPTION
Found this issue whilst updating to Big Sur

```
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the consensys/teku tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/consensys/homebrew-teku/teku.rb:8
````