### PR TITLE
Update to 22.1.0

### DIFF
--- a/teku.rb
+++ b/teku.rb
@@ -1,9 +1,9 @@
 class Teku < Formula
   desc "Teku Ethereum 2 beacon chain client"
   homepage "https://github.com/consensys/teku"
-  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/21.12.2/teku-21.12.2.zip"
+  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/22.1.0/teku-22.1.0.zip"
   # update with: ./updateTeku.sh <new-version>
-  sha256 "0c8adbc974b2238f721fe9231ef17291c6203034f10514d581f1eb4421046f5e"
+  sha256 "90c2a7dbbb3cabdfc9c7227ff127e5be66989de76def71ee09fa59a5ce636dbf"
   head "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/develop/teku-develop.zip"
 
   depends_on "openjdk" => "11+"

--- a/teku.rb
+++ b/teku.rb
@@ -4,6 +4,7 @@ class Teku < Formula
   url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/21.12.1/teku-21.12.1.zip"
   # update with: ./updateTeku.sh <new-version>
   sha256 "977bba9f52ddf96bccdc4af7c1efef94fcbd166b19f9b8babbac5afecac4807a"
+  head "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/develop/teku-develop.zip"
 
   depends_on "openjdk" => "11+"
 

--- a/updateTeku.sh
+++ b/updateTeku.sh
@@ -24,6 +24,7 @@ class Teku < Formula
   url "${URL}"
   # update with: ./updateTeku.sh <new-version>
   sha256 "${HASH}"
+  head "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/develop/teku-develop.zip"
 
   depends_on "openjdk" => "11+"
 


### PR DESCRIPTION
Update to Teku 22.1.0

Add support for installing develop version with --head
`brew install --head teku` will now install the latest develop build.  `brew install teku` continues to install the latest release.