### PR TITLE
Add configuration for brew services

### DIFF
--- a/teku.rb
+++ b/teku.rb
@@ -11,6 +11,24 @@ class Teku < Formula
   def install
     cp_r ".", "#{prefix}/dist"
     bin.install_symlink "#{prefix}/dist/bin/teku"
+
+    (buildpath/"teku.yaml").write <<~EOS
+      # Default Homebrew Teku config
+      network: "mainnet"
+      data-path: "#{etc}/teku.yaml"
+    EOS
+    etc.install "teku.yaml"
+  end
+
+  def post_install
+    # Make sure the var/teku directory exists
+    (var/"teku").mkpath
+  end
+
+  service do
+    run [opt_bin/"teku", "--config-file=#{etc}/teku.yaml"]
+    keep_alive true
+    working_dir var/"teku"
   end
 
   test do


### PR DESCRIPTION
Add a services configuration so teku can be started with `brew services start teku` and run as a daemon.