### PR TITLE
Release 26.4.0

### DIFF
--- a/teku.rb
+++ b/teku.rb
@@ -1,9 +1,9 @@
 class Teku < Formula
   desc "Teku Ethereum 2 beacon chain client"
   homepage "https://github.com/consensys/teku"
-  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/26.3.0/teku-26.3.0.zip"
+  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/26.4.0/teku-26.4.0.zip"
   # update with: ./updateTeku.sh <new-version>
-  sha256 "c34c8e39c5efc33cb7cb9cb0e1f8ffdcb57aee6c1cde4fc80a995b68da233978"
+  sha256 "9c3c95cc659fea6f2bfddf0509d93a8e0f1a140ab5a6ccefdce12a134e294550"
   head "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/develop/teku-develop.zip"
 
   depends_on "openjdk" => "21+"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a version/checksum bump in the Homebrew formula with no logic changes beyond fetching a new upstream artifact.
> 
> **Overview**
> Updates `teku.rb` to **Teku 26.4.0** by changing the artifact `url` and `sha256` to match the new release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d105f6021b90d281a81725f78801c6c3564f2b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->