### PR TITLE
Release 26.7.0

### DIFF
--- a/teku.rb
+++ b/teku.rb
@@ -1,9 +1,9 @@
 class Teku < Formula
   desc "Teku Ethereum 2 beacon chain client"
   homepage "https://github.com/consensys/teku"
-  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/26.6.1/teku-26.6.1.zip"
+  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/26.7.0/teku-26.7.0.zip"
   # update with: ./updateTeku.sh <new-version>
-  sha256 "a8dce0202a9989ab85d735ef06d1eb663258497148c792c8d548735d53a59b81"
+  sha256 "27c411fc03d68b11e1dfd1142c3e42dbc6a8044ed6dd88763a6b494e62ea20e3"
   head "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/develop/teku-develop.zip"
 
   depends_on "openjdk" => "21+"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only formula bump with no changes to install or runtime configuration.
> 
> **Overview**
> Bumps the Homebrew **Teku** formula from **26.6.1** to **26.7.0**.
> 
> Only the artifact `url` and matching `sha256` in `teku.rb` change; install, service, and test blocks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065abb6842e4aa9673cbc9201de360f2355a7e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->