### PR TITLE
Release 26.7.1

### DIFF
--- a/teku.rb
+++ b/teku.rb
@@ -1,9 +1,9 @@
 class Teku < Formula
   desc "Teku Ethereum 2 beacon chain client"
   homepage "https://github.com/consensys/teku"
-  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/26.7.0/teku-26.7.0.zip"
+  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/26.7.1/teku-26.7.1.zip"
   # update with: ./updateTeku.sh <new-version>
-  sha256 "27c411fc03d68b11e1dfd1142c3e42dbc6a8044ed6dd88763a6b494e62ea20e3"
+  sha256 "de3bf274ca05f6fa885505db01c591cc5a5f92699edc28e21abf7d92eff3895f"
   head "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/develop/teku-develop.zip"
 
   depends_on "openjdk" => "21+"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and checksum-only change in a packaging formula; no application logic or security-sensitive code modified.
> 
> **Overview**
> Bumps the Homebrew **Teku** formula from **26.7.0** to **26.7.1**.
> 
> Updates the artifact `url` and `sha256` to point at the **26.7.1** zip on Consensys artifacts. Install layout, dependencies, and service config are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88383f066296f3a9c9282018110c8578893e7d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->