### PR TITLE
Release 26.8.0

### DIFF
--- a/teku.rb
+++ b/teku.rb
@@ -1,9 +1,9 @@
 class Teku < Formula
   desc "Teku Ethereum 2 beacon chain client"
   homepage "https://github.com/consensys/teku"
-  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/26.7.1/teku-26.7.1.zip"
+  url "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/26.8.0/teku-26.8.0.zip"
   # update with: ./updateTeku.sh <new-version>
-  sha256 "de3bf274ca05f6fa885505db01c591cc5a5f92699edc28e21abf7d92eff3895f"
+  sha256 "e29759d182442ea26096188796f69bbb8d46d987534128edf27ffb5e955bfeb4"
   head "https://artifacts.consensys.net/public/teku/raw/names/teku.zip/versions/develop/teku-develop.zip"
 
   depends_on "openjdk" => "21+"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Routine version bump in a packaging formula with no application or security logic changes.
> 
> **Overview**
> Bumps the Homebrew **Teku** formula from **26.7.1** to **26.8.0**.
> 
> The artifact **download URL** and **SHA256** checksum in `teku.rb` are updated to match the new Consensys release zip; install, service, and test logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01d5ed26b582ac2c86431a880e398a6c8990bee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->